### PR TITLE
Clean up responsibilities between typing tool and example

### DIFF
--- a/common/changes/@kickstartds/jsonschema2types/fix-type-generation-responsibilities_2023-09-24-20-29.json
+++ b/common/changes/@kickstartds/jsonschema2types/fix-type-generation-responsibilities_2023-09-24-20-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kickstartds/jsonschema2types",
+      "comment": "don't write files, return record of generated types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kickstartds/jsonschema2types"
+}

--- a/common/changes/@kickstartds/types-example/fix-type-generation-responsibilities_2023-09-24-20-29.json
+++ b/common/changes/@kickstartds/types-example/fix-type-generation-responsibilities_2023-09-24-20-29.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@kickstartds/types-example",
+      "comment": "write files in example code now",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@kickstartds/types-example"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -111,6 +111,7 @@ importers:
       eslint-plugin-json-files: ~2.2.0
       import-meta-resolve: ~3.0.0
       json-schema-typed: ~8.0.1
+      pascal-case: ^3.1.2
       prettier: ^2.8.8
       typescript: ^5.0.4
     dependencies:
@@ -131,6 +132,7 @@ importers:
       eslint-plugin-json-files: 2.2.0_eslint@8.50.0
       import-meta-resolve: 3.0.0
       json-schema-typed: 8.0.1
+      pascal-case: 3.1.2
       prettier: 2.8.8
       typescript: 5.2.2
 
@@ -2154,6 +2156,24 @@ packages:
       - supports-color
     dev: false
 
+  /@kickstartds/base/2.2.0_@kickstartds+core@2.2.0:
+    resolution: {integrity: sha512-r6y24lO0wGb6Cffh1wD1irIZukvwdaWgxLnRUgXDKhyRacq2AVqNzFYm0N+ONlphvQxVbz8+UySfMojIq3rl8Q==}
+    peerDependencies:
+      '@kickstartds/core': ^2.0.3
+      react: ^17.0.2 || ^18.2.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.22.15
+      '@kickstartds/core': 2.2.0
+      classnames: 2.3.2
+      focus-visible: 5.2.0
+      markdown-to-jsx: 7.3.2
+      photoswipe: 5.4.1
+      vhtml: 2.2.0
+    dev: false
+
   /@kickstartds/base/2.3.0-canary.1457.6134.0_csr3ojkgoyupmsr3ttihnzezaa:
     resolution: {integrity: sha512-XB5y+nzgydmcr4RYT3GVW1/HZSPpwI5ygGvUJYg3tWu/5eAdoIZCNP0WAL8Sfw7/Yl8/+6TG3v8My1xv7Va18w==}
     peerDependencies:
@@ -2181,15 +2201,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.22.15
-      '@kickstartds/base': 2.0.4-next.5
+      '@kickstartds/base': 2.2.0_@kickstartds+core@2.2.0
       '@kickstartds/core': 2.2.0
       classnames: 2.3.2
       date-fns: 2.30.0
     transitivePeerDependencies:
       - '@storybook/types'
-      - '@types/react'
       - storybook-design-token
-      - supports-color
     dev: false
 
   /@kickstartds/blog/2.3.0-canary.1457.6134.0_icoklxzolwd42p7jpuchqzifyq:
@@ -2393,14 +2411,12 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': 7.22.15
-      '@kickstartds/base': 2.0.4-next.5
+      '@kickstartds/base': 2.2.0_@kickstartds+core@2.2.0
       '@kickstartds/core': 2.2.0
       classnames: 2.3.2
     transitivePeerDependencies:
       - '@storybook/types'
-      - '@types/react'
       - storybook-design-token
-      - supports-color
     dev: false
 
   /@kickstartds/form/2.3.0-canary.1457.6134.0_icoklxzolwd42p7jpuchqzifyq:

--- a/examples/types/package.json
+++ b/examples/types/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-json-files": "~2.2.0",
     "import-meta-resolve": "~3.0.0",
     "json-schema-typed": "~8.0.1",
+    "pascal-case": "^3.1.2",
     "prettier": "^2.8.8",
     "typescript": "^5.0.4"
   },

--- a/tools/jsonschema2types/src/index.ts
+++ b/tools/jsonschema2types/src/index.ts
@@ -1,41 +1,16 @@
-import { writeFileSync, mkdirSync } from 'node:fs';
-
-// import $RefParser from '@bcherny/json-schema-ref-parser';
 import { compile } from '@kickstartds/json-schema-to-typescript';
-import {
-  getSchemaName,
-  getSchemaModule,
-  getSchemasForIds,
-  isLayering,
-  layeredSchemaId
-} from '@kickstartds/jsonschema-utils';
+import { getSchemaName, getSchemasForIds } from '@kickstartds/jsonschema-utils';
 import { JSONSchema4 } from 'json-schema';
 import { pascalCase } from 'pascal-case';
 
 declare type MyAjv = import('ajv').default;
 
-export async function createTypes(schemaIds: string[], kdsSchemaIds: string[], ajv: MyAjv): Promise<void> {
-  // const schemaDomain = 'kickstartds.com';
-  // const kdsResolver: $RefParser.ResolverOptions = {
-  //   canRead: new RegExp(`^http:\/\/schema\.kickstartds\.com`, 'i'),
-  //   async read(file: $RefParser.FileInfo) {
-  //     return ajv.getSchema(file.url);
-  //   }
-  // };
-
-  // const customResolver: $RefParser.ResolverOptions = {
-  //   canRead: new RegExp(`^http:\/\/${schemaDomain.replaceAll('.', '.')}`, 'i'),
-  //   async read(file: $RefParser.FileInfo) {
-  //     return ajv.getSchema(file.url);
-  //   }
-  // };
-
+export async function createTypes(schemaIds: string[], ajv: MyAjv): Promise<Record<string, string>> {
+  const generatedTypings: Record<string, string> = {};
   const schemas = getSchemasForIds(schemaIds, ajv);
 
-  mkdirSync('dist', { recursive: true });
   for (const schema of schemas) {
     if (!schema.$id) throw new Error("Can't process a schema without $id");
-    // writeFileSync(`dist/${getSchemaName(schema.$id)}.schema.json`, JSON.stringify(schema, null, 2));
 
     const typings = await compile(
       {
@@ -53,18 +28,8 @@ export async function createTypes(schemaIds: string[], kdsSchemaIds: string[], a
       }
     );
 
-    const layeredId = isLayering(schema.$id, kdsSchemaIds)
-      ? layeredSchemaId(schema.$id, kdsSchemaIds)
-      : schema.$id;
-
-    // console.log(layeredId, schema.$id, isLayering(schema.$id, kdsSchemaIds));
-
-    writeFileSync(
-      `dist/${pascalCase(getSchemaName(layeredId))}Props.ts`,
-      `declare module "@kickstartds/${getSchemaModule(layeredId)}/lib/${getSchemaName(layeredId)}/typing" {
-${typings}
-}
-    `
-    );
+    generatedTypings[schema.$id] = typings;
   }
+
+  return generatedTypings;
 }


### PR DESCRIPTION
Files shouldn't be written by the tool itself, but the example showing its use. That makes adopting the tool inside other code (like the `kickstartDS-cli`) way easier.